### PR TITLE
now, when no arguments are passed to 'showstat.py' script, the script…

### DIFF
--- a/bin/showstat.py
+++ b/bin/showstat.py
@@ -4,15 +4,17 @@ import os
 from os import path
 import re
 import subprocess as sp
+import datetime
 
 SCRIPT_DIR = path.dirname(path.realpath(__file__))
+TODAY = datetime.date.today().isoformat()
 
 def parse_arguments(parser):
-    parser.add_argument("log_dir", help="Specifies a directory where log files are.")
+    parser.add_argument("log_dir", nargs='?', default=path.join(SCRIPT_DIR, "..", "log", TODAY), help="Specifies a directory where log files are.")
     parser.add_argument("-a", "--all", action="store_true", help="Shows entire status, not current status.")
     args = parser.parse_args()
     if not path.isdir(args.log_dir):
-        parser.error("LOG_DIR is not a directory")
+        parser.error(args.log_dir + " is not a directory")
     return args
 
 

--- a/documents/showstat.md
+++ b/documents/showstat.md
@@ -6,10 +6,10 @@
 # 사용법
 
 ```
-python3 showstat.py [-a] LOG_DIR
+python3 showstat.py [-a] [LOG_DIR]
 or
-./showstat.py [-a] LOG_DIR
+./showstat.py [-a] [LOG_DIR]
 ```
 
-- LOG_DIR: general.log 와 detail log들이 있는 디렉토리를 지정한다. 없는 디렉토리인 경우 에러를 출력한다.
+- LOG_DIR: general.log 와 detail log들이 있는 디렉토리를 지정한다. 없는 디렉토리인 경우 에러를 출력한다. 지정되지 않은 경우 "$ProjectRoot/log/$TODAY"로 지정된다.
 - -a, --all: 이 옵션이 지정되면 하루동안 일어났던 작업들을 모두 표시하고, 생성된 댓글을 표시할 때 원본 기사의 URL까지 표시한다. 지정되지 않은 경우 가장 최근의 상태만 보여준다.


### PR DESCRIPTION
… uses a default log directory